### PR TITLE
VIVI-16928 Fix node-fetch alias, keeping it backwards compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 const dotenv = require('dotenv');
 const fs = require('fs').promises;
-const fetch = require('node-fetch');
+
+// Fixes fetch import for node 18+, but also backwards compatible
+const fetch = globalThis.fetch ?? ((...args) =>
+  import('node-fetch').then(({ default: f }) => f(...args)));
 
 const { SourceFiles, Translations, UploadStorage } = require('@crowdin/crowdin-api-client');
 const path = require('path');

--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
 const dotenv = require('dotenv');
 const fs = require('fs').promises;
 
-// Fixes fetch import for node 18+, but also backwards compatible
-const fetch = globalThis.fetch ?? ((...args) =>
-  import('node-fetch').then(({ default: f }) => f(...args)));
-
 const { SourceFiles, Translations, UploadStorage } = require('@crowdin/crowdin-api-client');
 const path = require('path');
 


### PR DESCRIPTION
Node 18+ has fetch available globally so the node-fetch import is causing a collision in index.js.

This PR fixes the alias while also keeping it backwards compatible. It's probably not really needed since we pin commit hashes in this repo in the package.json but might prevent someone a headache in the future.